### PR TITLE
fix "Uncaught TypeError: Cannot set property 'moment' of undefined" E…

### DIFF
--- a/moment-jdateformatparser.js
+++ b/moment-jdateformatparser.js
@@ -173,7 +173,7 @@
     if (typeof module !== 'undefined' && module !== null) {
       module.exports = moment;
     } else {
-      this.moment = moment;
+      window.moment = moment;
     }
   }
 


### PR DESCRIPTION
…rror

When packaged into one js file with other plugins which might add "use strict", this "Uncaught TypeError: Cannot set property 'moment' of undefined" will be thrown.