### PR TITLE
Removed the bundled `moment`-dependency from `package.json` as it will

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
       "type": "MIT"
     }
   ],
-  "dependencies": {
-    "moment": "~2.9.0"
-  },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.7.1",


### PR DESCRIPTION
load the wrong instance of `moment.js` (the bundled version instead of
the one the user has already required/loaded) and therefore is not reachable
anymore if the user "just requires" this plugin after `moment`.

So this was the error case, which is resolved now:
```javascript
const moment = require('moment');
const mJDateFormatParser = require('moment-jdateformatparser');

// will throw error as the jdateformatparser instance is registered
// at the moment-instance which is bundled with the plugin!
console.log(moment().formatWithJDF('dd.MM.yyyy'));
```

Now it is required, that the user loads the `moment`-library first which
is what should be expected anyways, as the bundled moment-instance is
never reachable as it's not exported by the plugin.

Fixes #28 